### PR TITLE
Find and fix one bug

### DIFF
--- a/src/entities/Vehicle.test.ts
+++ b/src/entities/Vehicle.test.ts
@@ -107,6 +107,18 @@ describe('Vehicle', () => {
       vehicle.steerRight(0.016);
       expect(vehicle.rotation).toBe(initialRotation);
     });
+
+    it('should steer when moving in reverse', () => {
+      vehicle.speed = -50; // Negative speed (reverse)
+      const initialRotation = vehicle.rotation;
+      
+      vehicle.steerLeft(0.016);
+      expect(vehicle.rotation).toBeLessThan(initialRotation);
+      
+      vehicle.rotation = initialRotation;
+      vehicle.steerRight(0.016);
+      expect(vehicle.rotation).toBeGreaterThan(initialRotation);
+    });
   });
 
   describe('bounds', () => {

--- a/src/entities/Vehicle.ts
+++ b/src/entities/Vehicle.ts
@@ -71,14 +71,15 @@ export class Vehicle {
 
   steerLeft(deltaTime: number): void {
     // Only allow steering when moving
-    if (this.speed > 10) {
-      this.rotation -= this.turnSpeed * deltaTime * (this.speed / this.maxSpeed);
+    if (Math.abs(this.speed) > 10) {
+      this.rotation -= this.turnSpeed * deltaTime * (Math.abs(this.speed) / this.maxSpeed);
     }
   }
+  
   steerRight(deltaTime: number): void {
     // Only allow steering when moving
-    if (this.speed > 10) {
-      this.rotation += this.turnSpeed * deltaTime * (this.speed / this.maxSpeed);
+    if (Math.abs(this.speed) > 10) {
+      this.rotation += this.turnSpeed * deltaTime * (Math.abs(this.speed) / this.maxSpeed);
     }
   }
 


### PR DESCRIPTION
Fix vehicle steering to work correctly when moving in reverse.

Initially, the vehicle could not steer when moving backward due to a `speed > 10` check. After fixing this to use `Math.abs(speed)`, a secondary bug was discovered where the steering direction was inverted in reverse. The final fix addresses both issues by using `Math.abs(speed)` for both the steering condition and the steering calculation, ensuring consistent and correct steering in all directions. A new test case was added to verify the fix.